### PR TITLE
Service status startup mode check for windows custom extensions

### DIFF
--- a/playbooks/machine.yaml
+++ b/playbooks/machine.yaml
@@ -87,6 +87,7 @@
             extension_file: 'WindowsCustomExtensions.zip' 
             extension_template: "win-custom-extension-config.json.j2"
             extension_vars: "custom_extension_win_config" # no file extension
+            extension_business_logic: "windows_custom_extension_business_logic"
 
         custom_extensions_linux:
           ProcessMonitor:

--- a/playbooks/roles/machine/tasks/configure_custom_extensions_win.yml
+++ b/playbooks/roles/machine/tasks/configure_custom_extensions_win.yml
@@ -106,6 +106,23 @@
   with_dict: "{{ custom_extensions_windows }}"
   when: is_support_group_paas | bool == True
 
+## Include custom business logic when defined
+- include_tasks: custom_extension_business_logic/{{ item.value.extension_business_logic }}.yml
+  with_dict: "{{ custom_extensions_windows }}"
+  when: 
+    - item.value.enabled | bool == True
+    - item.value.extension_business_logic is defined
+
+# 
+- name: Overwrite variables for PaaS systems when "Cluster Service" monitoring is not enabled
+  include_vars:
+    file: custom_extension_vars/{{ item.value.extension_vars }}.paas.cluster_service_disabled.yml
+  with_dict: "{{ custom_extensions_windows }}"
+  when: 
+  - is_support_group_paas | bool == True
+  - cluster_service_enabled is defined 
+  - cluster_service_enabled|bool == False
+
 # Configure
 - name: Configure Custom Extension config file - if Custom Extension is enabled
   template:

--- a/playbooks/roles/machine/tasks/custom_extension_business_logic/windows_custom_extension_business_logic.yml
+++ b/playbooks/roles/machine/tasks/custom_extension_business_logic/windows_custom_extension_business_logic.yml
@@ -1,0 +1,45 @@
+---
+- name: Return "Cluster Service" info
+  ansible.windows.win_service_info:
+    name: "AWS Lite Guest Agent" # "Cluster Service" 
+  register: service_info
+
+- name: Get Service startup mode
+  set_fact:
+    service_startup_mode: "{{ service_info.services[0].start_mode }}"
+  when: service_info is defined and service_info.services is defined
+
+- name: Print service_startup_mode value
+  ansible.builtin.debug:
+    msg: "service_startup_mode={{ service_startup_mode }}"
+  when: service_startup_mode is defined
+
+- name: Set variable values when "Cluster Service" startup-mode is "auto"
+  set_fact:
+    win_enable_cluster_disk_monitor_final: 1
+    win_enable_cluster_network_monitor_final: 1
+    win_enable_cluster_node_monitor_final: 1
+    win_enable_cluster_roles_monitor_final: 1
+  when: 
+  - service_startup_mode is defined
+  - service_startup_mode == "auto"
+
+- name: Set variable values when "Cluster Service" startup-mode is not "auto"
+  set_fact:
+    win_enable_cluster_disk_monitor_final: 0
+    win_enable_cluster_network_monitor_final: 0
+    win_enable_cluster_node_monitor_final: 0
+    win_enable_cluster_roles_monitor_final: 0
+  when: 
+  - service_startup_mode is defined 
+  - service_startup_mode != "auto"
+
+- name: Print Cluster Monitor final values
+  ansible.builtin.debug:
+    msg: 
+    - "win_enable_cluster_disk_monitor_final: {{ win_enable_cluster_disk_monitor_final }}"
+    - "win_enable_cluster_network_monitor_final: {{ win_enable_cluster_network_monitor_final }}"
+    - "win_enable_cluster_node_monitor_final: {{ win_enable_cluster_node_monitor_final }}"
+    - "win_enable_cluster_roles_monitor_final: {{ win_enable_cluster_roles_monitor_final }}"
+  when: service_startup_mode is defined
+

--- a/playbooks/roles/machine/tasks/custom_extension_business_logic/windows_custom_extension_business_logic.yml
+++ b/playbooks/roles/machine/tasks/custom_extension_business_logic/windows_custom_extension_business_logic.yml
@@ -1,45 +1,32 @@
 ---
 - name: Return "Cluster Service" info
   ansible.windows.win_service_info:
-    name: "AWS Lite Guest Agent" # "Cluster Service" 
+    name: "Cluster Service"
   register: service_info
 
 - name: Get Service startup mode
   set_fact:
     service_startup_mode: "{{ service_info.services[0].start_mode }}"
-  when: service_info is defined and service_info.services is defined
+  when: service_info is defined and  service_info.exists|bool == True
 
 - name: Print service_startup_mode value
   ansible.builtin.debug:
     msg: "service_startup_mode={{ service_startup_mode }}"
   when: service_startup_mode is defined
 
-- name: Set variable values when "Cluster Service" startup-mode is "auto"
+- name: Set cluster_service_enabled to false by default
   set_fact:
-    win_enable_cluster_disk_monitor_final: 1
-    win_enable_cluster_network_monitor_final: 1
-    win_enable_cluster_node_monitor_final: 1
-    win_enable_cluster_roles_monitor_final: 1
+    cluster_service_enabled: false
+
+- name: Update cluster_service_enabled when "Cluster Service" startup-mode is "auto"
+  set_fact:
+    cluster_service_enabled: true
   when: 
   - service_startup_mode is defined
   - service_startup_mode == "auto"
 
-- name: Set variable values when "Cluster Service" startup-mode is not "auto"
-  set_fact:
-    win_enable_cluster_disk_monitor_final: 0
-    win_enable_cluster_network_monitor_final: 0
-    win_enable_cluster_node_monitor_final: 0
-    win_enable_cluster_roles_monitor_final: 0
-  when: 
-  - service_startup_mode is defined 
-  - service_startup_mode != "auto"
-
-- name: Print Cluster Monitor final values
+- name: Print cluster_service_enabled value
   ansible.builtin.debug:
-    msg: 
-    - "win_enable_cluster_disk_monitor_final: {{ win_enable_cluster_disk_monitor_final }}"
-    - "win_enable_cluster_network_monitor_final: {{ win_enable_cluster_network_monitor_final }}"
-    - "win_enable_cluster_node_monitor_final: {{ win_enable_cluster_node_monitor_final }}"
-    - "win_enable_cluster_roles_monitor_final: {{ win_enable_cluster_roles_monitor_final }}"
-  when: service_startup_mode is defined
+    msg: "cluster_service_enabled={{ cluster_service_enabled }}"
+  when: cluster_service_enabled is defined
 

--- a/playbooks/roles/machine/templates/custom_extensions/win-custom-extension-config.json.j2
+++ b/playbooks/roles/machine/templates/custom_extensions/win-custom-extension-config.json.j2
@@ -12,7 +12,7 @@
     "EnableClusterDiskMonitor": "{{ win_enable_cluster_disk_monitor }}",
     "EnableClusterNetworkMonitor": "{{ win_enable_cluster_network_monitor }}",
     "EnableClusterNodeMonitor": "{{ win_enable_cluster_node_monitor }}",
-    "EnableClusterRolesMonitor": "{{ win_enable_cluster_roles_monitor }}"
+    "EnableClusterRolesMonitor": "{{ win_enable_cluster_roles_monitor }}",
 
     "windows_events_log": [{
             "Application": {{event_log_application}}

--- a/playbooks/roles/machine/templates/custom_extensions/win-custom-extension-config.json.j2
+++ b/playbooks/roles/machine/templates/custom_extensions/win-custom-extension-config.json.j2
@@ -9,10 +9,10 @@
     "EnableWindowsEventMonitor": "{{ win_enable_event_monitor }}",
     "EnableWindowsServiceMonitor": "{{ win_enable_service_monitor }}",
     "EnableWindowsTaskSchedulerMonitor": "{{ win_enable_task_scheduler_monitor }}",
-    "EnableClusterDiskMonitor": "{{ win_enable_cluster_disk_monitor_final if win_enable_cluster_disk_monitor_final is defined else win_enable_cluster_disk_monitor }}",
-    "EnableClusterNetworkMonitor": "{{ win_enable_cluster_network_monitor_final if win_enable_cluster_network_monitor_final is defined else win_enable_cluster_network_monitor }}",
-    "EnableClusterNodeMonitor": "{{ win_enable_cluster_node_monitor_final if win_enable_cluster_node_monitor_final is defined else win_enable_cluster_node_monitor }}",
-    "EnableClusterRolesMonitor": "{{ win_enable_cluster_roles_monitor_final if win_enable_cluster_roles_monitor_final is defined else win_enable_cluster_roles_monitor }}"
+    "EnableClusterDiskMonitor": "{{ win_enable_cluster_disk_monitor }}",
+    "EnableClusterNetworkMonitor": "{{ win_enable_cluster_network_monitor }}",
+    "EnableClusterNodeMonitor": "{{ win_enable_cluster_node_monitor }}",
+    "EnableClusterRolesMonitor": "{{ win_enable_cluster_roles_monitor }}"
 
     "windows_events_log": [{
             "Application": {{event_log_application}}

--- a/playbooks/roles/machine/templates/custom_extensions/win-custom-extension-config.json.j2
+++ b/playbooks/roles/machine/templates/custom_extensions/win-custom-extension-config.json.j2
@@ -9,10 +9,10 @@
     "EnableWindowsEventMonitor": "{{ win_enable_event_monitor }}",
     "EnableWindowsServiceMonitor": "{{ win_enable_service_monitor }}",
     "EnableWindowsTaskSchedulerMonitor": "{{ win_enable_task_scheduler_monitor }}",
-    "EnableClusterDiskMonitor": "{{ win_enable_cluster_disk_monitor }}",
-    "EnableClusterNetworkMonitor": "{{ win_enable_cluster_network_monitor }}",
-    "EnableClusterNodeMonitor": "{{ win_enable_cluster_node_monitor}}",
-    "EnableClusterRolesMonitor": "{{ win_enable_cluster_roles_monitor }}",
+    "EnableClusterDiskMonitor": "{{ win_enable_cluster_disk_monitor_final if win_enable_cluster_disk_monitor_final is defined else win_enable_cluster_disk_monitor }}",
+    "EnableClusterNetworkMonitor": "{{ win_enable_cluster_network_monitor_final if win_enable_cluster_network_monitor_final is defined else win_enable_cluster_network_monitor }}",
+    "EnableClusterNodeMonitor": "{{ win_enable_cluster_node_monitor_final if win_enable_cluster_node_monitor_final is defined else win_enable_cluster_node_monitor }}",
+    "EnableClusterRolesMonitor": "{{ win_enable_cluster_roles_monitor_final if win_enable_cluster_roles_monitor_final is defined else win_enable_cluster_roles_monitor }}"
 
     "windows_events_log": [{
             "Application": {{event_log_application}}

--- a/playbooks/roles/machine/vars/custom_extension_vars/custom_extension_win_config.paas.cluster_service_disabled.yml
+++ b/playbooks/roles/machine/vars/custom_extension_vars/custom_extension_win_config.paas.cluster_service_disabled.yml
@@ -4,7 +4,7 @@
 
 #Event attributes:
 win_appname: "165"
-win_oauthtoken: "PaaS"
+win_oauthtoken: "PaaSClusterDisabled"
 win_enable_events: 0
 
 #Enabling logging: values "0" (disabled) or "1" (enabled) -
@@ -14,10 +14,10 @@ win_enable_logging: 0
 win_enable_event_monitor: 1 
 win_enable_service_monitor: 1 
 win_enable_task_scheduler_monitor: 1 
-win_enable_cluster_disk_monitor: 1
-win_enable_cluster_network_monitor: 1
-win_enable_cluster_node_monitor: 1
-win_enable_cluster_roles_monitor: 1
+win_enable_cluster_disk_monitor: 0
+win_enable_cluster_network_monitor: 0
+win_enable_cluster_node_monitor: 0
+win_enable_cluster_roles_monitor: 0
 
 #Below are values for Event Log:
 event_log_application: '["App 1", "App2", "App3"]'

--- a/playbooks/roles/machine/vars/custom_extension_vars/custom_extension_win_config.yml
+++ b/playbooks/roles/machine/vars/custom_extension_vars/custom_extension_win_config.yml
@@ -4,7 +4,7 @@
 
 #Event attributes:
 win_appname: "165"
-win_oauthtoken: "testtesttesttesttest"
+win_oauthtoken: "NonPaaS"
 win_enable_events: 0
 
 #Enabling logging: values "0" (disabled) or "1" (enabled) -


### PR DESCRIPTION
- Include windows custom extension business logic tasks if defined
- Check if "Cluster Service" exists and had startup_mode auto
- Adjust custom extension variables accordingly
- Update extension templates